### PR TITLE
Fix blog links to honor path prefix

### DIFF
--- a/docs/blog/index.html
+++ b/docs/blog/index.html
@@ -34,7 +34,7 @@
   
     <li>
       <article>
-        <h2><a href="/blog/welcome/">Welcome to Tomorrow&#39;s Bread Today Blog</a></h2>
+        <h2><a href="/tbt-org/blog/welcome/">Welcome to Tomorrow&#39;s Bread Today Blog</a></h2>
         <p class="post-meta">January 15, 2024</p>
         <p>An introduction to our new static home and what to expect in future updates.</p>
       </article>

--- a/pages/blog/index.njk
+++ b/pages/blog/index.njk
@@ -11,7 +11,7 @@ permalink: /blog/index.html
   {% for post in collections.blog %}
     <li>
       <article>
-        <h2><a href="{{ post.url }}">{{ post.data.title }}</a></h2>
+        <h2><a href="{{ post.url | url }}">{{ post.data.title }}</a></h2>
         <p class="post-meta">{{ post.date | readableDate }}</p>
         <p>{{ post.data.summary }}</p>
       </article>


### PR DESCRIPTION
## Summary
- update the blog index template to pass post URLs through Eleventy's `url` filter so links honor the configured path prefix
- rebuild the generated blog index page so GitHub Pages serves the corrected links

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db1b1feab08332857efdd414abb4a0