### PR TITLE
Add Tomorrow's Bread Today logo to site header

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -44,6 +44,33 @@ a:hover {
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
 }
 
+.site-header .container {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.site-branding {
+  display: flex;
+  align-items: center;
+  gap: 1.25rem;
+}
+
+.site-logo {
+  display: inline-flex;
+  align-items: center;
+}
+
+.site-logo img {
+  max-height: 96px;
+  width: auto;
+}
+
+.site-text {
+  display: flex;
+  flex-direction: column;
+}
+
 .site-title {
   margin: 0;
   font-size: 1.8rem;
@@ -102,6 +129,12 @@ a:hover {
 }
 
 @media (max-width: 600px) {
+  .site-branding {
+    align-items: flex-start;
+    flex-direction: column;
+    gap: 1rem;
+  }
+
   .site-main .content {
     padding: 1.25rem;
   }

--- a/layouts/base.njk
+++ b/layouts/base.njk
@@ -9,8 +9,15 @@
 <body>
   <header class="site-header">
     <div class="container">
-      <h1 class="site-title"><a href="{{ '/' | url }}">Tomorrow's Bread Today</a></h1>
-      <p class="tagline">Cooperative care rooted in community.</p>
+      <div class="site-branding">
+        <a class="site-logo" href="{{ '/' | url }}">
+          <img src="{{ '/assets/images/tbt-logo.png' | url }}" alt="Tomorrow's Bread Today logo">
+        </a>
+        <div class="site-text">
+          <h1 class="site-title"><a href="{{ '/' | url }}">Tomorrow's Bread Today</a></h1>
+          <p class="tagline">Cooperative care rooted in community.</p>
+        </div>
+      </div>
       <nav class="site-nav">
         <ul>
           <li><a href="{{ '/' | url }}">Home</a></li>


### PR DESCRIPTION
## Summary
- include the Tomorrow's Bread Today logo alongside the site title and tagline
- adjust header styling so the logo and branding content align while keeping the navigation separate

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68db308ea390833296bd1e83d5ff56ab